### PR TITLE
3dviewer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 workspace.py
 .vscode/
 
+workspace.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/bgviewer/viewer3d/__init__.py
+++ b/bgviewer/viewer3d/__init__.py
@@ -1,0 +1,12 @@
+from PyQt5 import QtWidgets
+from bgviewer.viewer3d.gui import MainWindow
+import sys
+
+
+def launch():
+    app = QtWidgets.QApplication(sys.argv)
+
+    window = MainWindow()
+    app.aboutToQuit.connect(window.onClose)  # <-- connect the onClose event
+    window.show()
+    sys.exit(app.exec_())

--- a/bgviewer/viewer3d/__init__.py
+++ b/bgviewer/viewer3d/__init__.py
@@ -1,6 +1,7 @@
 from PyQt5 import QtWidgets
 from bgviewer.viewer3d.gui import MainWindow
 import sys
+import argparse
 
 
 def launch(*args, **kwargs):
@@ -10,3 +11,41 @@ def launch(*args, **kwargs):
     app.aboutToQuit.connect(window.onClose)  # <-- connect the onClose event
     window.show()
     sys.exit(app.exec_())
+
+
+def launch_parser():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-f",
+        "--full-screen",
+        dest="fullscreen",
+        required=False,
+        default=False,
+        help="Pass True to have the viewer launch in fullscreen mode",
+    )
+
+    parser.add_argument(
+        "-t",
+        "--theme",
+        dest="theme",
+        required=False,
+        default="dark",
+        help="'dark' or 'light' color theme'",
+    )
+
+    parser.add_argument(
+        "-a",
+        "--atlas",
+        dest="atlas",
+        required=False,
+        default=None,
+        help="Pass the name of a brainglobe atlas to explore with the 3d viewer",
+    )
+
+    return parser
+
+
+def main():
+    args = launch_parser().parse_args()
+
+    launch(theme=args.theme, fullscreen=args.fullscreen, atlas=args.atlas)

--- a/bgviewer/viewer3d/__init__.py
+++ b/bgviewer/viewer3d/__init__.py
@@ -3,10 +3,10 @@ from bgviewer.viewer3d.gui import MainWindow
 import sys
 
 
-def launch():
+def launch(*args, **kwargs):
     app = QtWidgets.QApplication(sys.argv)
 
-    window = MainWindow()
+    window = MainWindow(*args, **kwargs)
     app.aboutToQuit.connect(window.onClose)  # <-- connect the onClose event
     window.show()
     sys.exit(app.exec_())

--- a/bgviewer/viewer3d/gui.py
+++ b/bgviewer/viewer3d/gui.py
@@ -58,8 +58,12 @@ class MainWindow(Window, Scene):
             When an item on the hierarchy tree is double clicked, the
             corresponding mesh is added/removed from the brainrender scene
         """
-        # Get time [instance of StandardItem]
-        item = self.hierarchy.selectedIndexes()[0]
+        # Get item
+        idxs = self.hierarchy.selectedIndexes()
+        if idxs:
+            item = idxs[0]
+        else:
+            return
         item = item.model().itemFromIndex(val)
 
         # Get region name

--- a/bgviewer/viewer3d/gui.py
+++ b/bgviewer/viewer3d/gui.py
@@ -1,6 +1,5 @@
 from vedo import Plotter
-from PyQt5 import QtWidgets
-from PyQt5.QtGui import QFont, QColor
+from PyQt5.QtGui import QFont
 import brainrender
 from brainrender.Utils.camera import set_camera
 from brainrender.scene import Scene
@@ -8,9 +7,8 @@ from brainrender.scene import Scene
 from bgviewer.viewer3d.ui import Window
 
 
-
-brainrender.BACKGROUND_COLOR = 'blackboard'
-brainrender.ROOT_COLOR = [.8, .8, .8]
+brainrender.BACKGROUND_COLOR = "blackboard"
+brainrender.ROOT_COLOR = [0.8, 0.8, 0.8]
 
 """
     A pyqt5-based GUI for visualising brian regions in 3d. 
@@ -19,7 +17,8 @@ brainrender.ROOT_COLOR = [.8, .8, .8]
     where the regions meshes are visualised
 """
 
-class MainWindow(Window,  Scene):
+
+class MainWindow(Window, Scene):
     # ---------------------------------- create ---------------------------------- #
     def __init__(self, *args, atlas=None, **kwargs):
         """
@@ -34,7 +33,6 @@ class MainWindow(Window,  Scene):
 
         # update plotter
         self._update()
-
 
     def setup_plotter(self):
         """
@@ -62,26 +60,25 @@ class MainWindow(Window,  Scene):
         region = item.tag
 
         # Add/remove mesh
-        if region == 'root' or region == 'grey':
+        if region == "root" or region == "grey":
             if self.root is None:
                 self.add_root()
         else:
-            if region not in self.actors['regions'].keys():
+            if region not in self.actors["regions"].keys():
                 # Add region
-                fnt = QFont('Open Sans', 12)
+                fnt = QFont("Open Sans", 12)
                 fnt.setBold(True)
                 item.setFont(fnt)
 
                 self.add_brain_regions(region)
             else:
-                del self.actors['regions'][region]
+                del self.actors["regions"][region]
 
             # Update hierarchy's item font
             item.toggle_active()
 
         # Update brainrender scene
         self._update()
-
 
     def _update(self):
         """
@@ -90,7 +87,11 @@ class MainWindow(Window,  Scene):
         """
         self.apply_render_style()
 
-        self.plotter.show(*self.get_actors(), interactorStyle=0, bg=brainrender.BACKGROUND_COLOR)
+        self.plotter.show(
+            *self.get_actors(),
+            interactorStyle=0,
+            bg=brainrender.BACKGROUND_COLOR,
+        )
 
         # Fake a button press to force update
         self.plotter.interactor.MiddleButtonPressEvent()
@@ -102,4 +103,3 @@ class MainWindow(Window,  Scene):
             Disable the interactor before closing to prevent it from trying to act on a already deleted items
         """
         self.vtkWidget.close()
-

--- a/bgviewer/viewer3d/gui.py
+++ b/bgviewer/viewer3d/gui.py
@@ -1,0 +1,105 @@
+from vedo import Plotter
+from PyQt5 import QtWidgets
+from PyQt5.QtGui import QFont, QColor
+import brainrender
+from brainrender.Utils.camera import set_camera
+from brainrender.scene import Scene
+
+from bgviewer.viewer3d.ui import Window
+
+
+
+brainrender.BACKGROUND_COLOR = 'blackboard'
+brainrender.ROOT_COLOR = [.8, .8, .8]
+
+"""
+    A pyqt5-based GUI for visualising brian regions in 3d. 
+    It consistets of a 'tree' widget to explore the hierarchy of
+    brain structures and an interactive brainrender Scene
+    where the regions meshes are visualised
+"""
+
+class MainWindow(Window,  Scene):
+    # ---------------------------------- create ---------------------------------- #
+    def __init__(self, *args, atlas=None, **kwargs):
+        """
+            Adds brainrender/vedo functionality to the 
+            pyqt5 application created in bgviewer.viewer3d.ui.Window
+        """
+        Window.__init__(self)
+        Scene.__init__(self, *args, atlas=atlas, **kwargs)
+
+        # Create a new vedo plotter
+        self.setup_plotter()
+
+        # update plotter
+        self._update()
+
+
+    def setup_plotter(self):
+        """
+            Changes the scene's default plotter
+            with one attached to the qtWidget in the 
+            pyqt application. 
+        """
+        new_plotter = Plotter(axes=None, qtWidget=self.vtkWidget)
+        self.plotter = new_plotter
+
+        # Fix camera
+        set_camera(self, self.camera)
+
+    # ---------------------------------- Update ---------------------------------- #
+    def show_hide_mesh(self, val):
+        """
+            When an item on the hierarchy tree is double clicked, the
+            corresponding mesh is added/removed from the brainrender scene
+        """
+        # Get time [instance of StandardItem]
+        item = self.hierarchy.selectedIndexes()[0]
+        item = item.model().itemFromIndex(val)
+
+        # Get region name
+        region = item.tag
+
+        # Add/remove mesh
+        if region == 'root' or region == 'grey':
+            if self.root is None:
+                self.add_root()
+        else:
+            if region not in self.actors['regions'].keys():
+                # Add region
+                fnt = QFont('Open Sans', 12)
+                fnt.setBold(True)
+                item.setFont(fnt)
+
+                self.add_brain_regions(region)
+            else:
+                del self.actors['regions'][region]
+
+            # Update hierarchy's item font
+            item.toggle_active()
+
+        # Update brainrender scene
+        self._update()
+
+
+    def _update(self):
+        """
+            Updates the scene's Plotter to add/remove
+            meshes
+        """
+        self.apply_render_style()
+
+        self.plotter.show(*self.get_actors(), interactorStyle=0, bg=brainrender.BACKGROUND_COLOR)
+
+        # Fake a button press to force update
+        self.plotter.interactor.MiddleButtonPressEvent()
+        self.plotter.interactor.MiddleButtonReleaseEvent()
+
+    # ----------------------------------- Close ---------------------------------- #
+    def onClose(self):
+        """
+            Disable the interactor before closing to prevent it from trying to act on a already deleted items
+        """
+        self.vtkWidget.close()
+

--- a/bgviewer/viewer3d/gui.py
+++ b/bgviewer/viewer3d/gui.py
@@ -1,5 +1,8 @@
 from vedo import Plotter
 from PyQt5.QtGui import QFont
+from PyQt5.Qt import Qt
+from PyQt5 import QtCore
+
 import brainrender
 from brainrender.Utils.camera import set_camera
 from brainrender.scene import Scene
@@ -7,7 +10,6 @@ from brainrender.scene import Scene
 from bgviewer.viewer3d.ui import Window
 
 
-brainrender.BACKGROUND_COLOR = "blackboard"
 brainrender.ROOT_COLOR = [0.8, 0.8, 0.8]
 
 """
@@ -25,14 +27,18 @@ class MainWindow(Window, Scene):
             Adds brainrender/vedo functionality to the 
             pyqt5 application created in bgviewer.viewer3d.ui.Window
         """
-        Window.__init__(self)
+        Window.__init__(self, *args, **kwargs)
         Scene.__init__(self, *args, atlas=atlas, **kwargs)
 
         # Create a new vedo plotter
+        brainrender.BACKGROUND_COLOR = [228, 229, 230]
         self.setup_plotter()
 
         # update plotter
         self._update()
+
+        # Add inset
+        self._get_inset()
 
     def setup_plotter(self):
         """
@@ -58,6 +64,14 @@ class MainWindow(Window, Scene):
 
         # Get region name
         region = item.tag
+
+        # Toggle checkbox
+        if not item._checked:
+            item.setCheckState(Qt.Checked)
+            item._checked = True
+        else:
+            item.setCheckState(Qt.Unchecked)
+            item._checked = False
 
         # Add/remove mesh
         if region == "root" or region == "grey":
@@ -98,6 +112,14 @@ class MainWindow(Window, Scene):
         self.plotter.interactor.MiddleButtonReleaseEvent()
 
     # ----------------------------------- Close ---------------------------------- #
+    def keyPressEvent(self, event):
+        if (
+            event.key() == QtCore.Qt.Key_Escape
+            or event.key() == QtCore.Qt.Key_Q
+            or event.key() == QtCore.Qt.Key_q
+        ):
+            self.close()
+
     def onClose(self):
         """
             Disable the interactor before closing to prevent it from trying to act on a already deleted items

--- a/bgviewer/viewer3d/ui.py
+++ b/bgviewer/viewer3d/ui.py
@@ -62,7 +62,7 @@ class StandardItem(QStandardItem):
         elif self.depth < 5:
             return 14, QColor(220, 220, 220)
         else:
-            return 16, QColor(180, 180, 180)
+            return 12, QColor(180, 180, 180)
 
 
 # ---------------------------------------------------------------------------- #
@@ -116,7 +116,7 @@ class Window(QMainWindow):
         main_layout = QHBoxLayout()
         main_layout.addWidget(left_widget)
         main_layout.addWidget(self.right_widget)
-        main_layout.setStretch(0, 40)
+        main_layout.setStretch(0, 80)
         main_layout.setStretch(1, 200)
         main_widget = QWidget()
         main_widget.setLayout(main_layout)
@@ -146,7 +146,9 @@ class Window(QMainWindow):
         treeView = QTreeView()
         treeView.setExpandsOnDoubleClick(False)
         treeView.setHeaderHidden(True)
-        treeView.setStyleSheet("background-color: rgb(80, 80, 80);")
+        treeView.setStyleSheet(
+            "background-color: rgb(80, 80, 80); border-radius: 12px; padding: 20px 12px;"
+        )
 
         treeModel = QStandardItemModel()
         rootNode = treeModel.invisibleRootItem()

--- a/bgviewer/viewer3d/ui.py
+++ b/bgviewer/viewer3d/ui.py
@@ -1,0 +1,185 @@
+from PyQt5.QtWidgets import *
+from PyQt5.Qt import QStandardItemModel, QStandardItem
+from PyQt5.QtGui import QFont, QColor
+from PyQt5 import QtCore
+
+import sys
+from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
+
+
+"""
+    Handles the UI for the 3d viewer based on the pyqt5 application
+"""
+
+# -------------------------------- tree items -------------------------------- #
+class StandardItem(QStandardItem):
+    def __init__(self, txt='', tag=None, depth=0):
+        """
+            Items in the tree list with some
+            extended functionality to specify/update
+            their look. 
+        """
+        super().__init__()
+        self.depth = depth  # depth in the hierarchy structure
+        self.tag = tag
+ 
+        # Set font color/size
+        fs, color = self.get_font_from_depth()
+        self.bold = True # but will be inverted
+        self.toggle_active()
+ 
+        # Set text
+        self.setEditable(False)
+        self.setForeground(color)
+        self.setText(txt)
+
+    def toggle_active(self):
+        """
+            When a mesh corresponding to the item's region
+            get's rendered, change the font to bold
+            to highlight the fact. 
+        """
+        self.bold = not self.bold
+        fs, color = self.get_font_from_depth()
+
+        fnt = QFont('Roboto', fs)
+        fnt.setBold(self.bold)
+        self.setFont(fnt)
+
+    def get_font_from_depth(self):
+        """
+            Given tree depth returns
+                font-size, bold, color
+        """
+        if self.depth < 2:
+            return 16, QColor(255, 255, 255)
+        elif self.depth< 5:
+            return 14, QColor(220, 220, 220)
+        else:
+            return 16, QColor(180, 180, 180)
+
+
+# ---------------------------------------------------------------------------- #
+#                                   UI CLASS                                   #
+# ---------------------------------------------------------------------------- #
+
+class Window(QMainWindow):
+    def __init__(self):
+        """
+            Create the pyqt window and the widgets
+        """
+        super().__init__()
+
+        # set the title of main window
+        self.setWindowTitle('Brainrender GUI')
+
+        # set the size of window
+        self.showFullScreen()
+
+        # Change baground color
+        self.setStyleSheet("background-color: rgb(40, 40, 40);") 
+
+        # add tabs
+        self.tab1 = self.brainrender_canvas()
+        self.initUI()
+
+    def initUI(self):
+        """
+            Define overall window layout
+        """
+        # Left layout
+        self.left_layout = QVBoxLayout()
+
+        self.hierarchy = self.hierarchy_widget()
+        self.left_layout.addWidget(self.hierarchy)
+        left_widget = QWidget()
+        left_widget.setLayout(self.left_layout)
+
+        # Right layout
+        self.right_widget = QTabWidget()
+        self.right_widget.tabBar().setObjectName("mainTab")
+        self.right_widget.addTab(self.tab1, '')
+        self.right_widget.setCurrentIndex(0)
+        self.right_widget.setStyleSheet('''QTabBar::tab{width: 0; \
+            height: 0; margin: 0; padding: 0; border: none;}''')
+
+        # Put everything together
+        main_layout = QHBoxLayout()
+        main_layout.addWidget(left_widget)
+        main_layout.addWidget(self.right_widget)
+        main_layout.setStretch(0, 40)
+        main_layout.setStretch(1, 200)
+        main_widget = QWidget()
+        main_widget.setLayout(main_layout)
+        self.setCentralWidget(main_widget)
+
+    def brainrender_canvas(self):
+        """
+            Create vtkWidget where brainrender's plotter
+            will be visualised
+        """
+        self.vtkWidget = QVTKRenderWindowInteractor(self)
+
+        main_layout = QVBoxLayout()
+        main_layout.addWidget(self.vtkWidget)
+        main = QWidget()
+        main.setLayout(main_layout)
+        return main
+
+    def hierarchy_widget(self):
+        """
+            Creates the structures tree hierarchy widget and populates 
+            it with structures names from the brainglobe-api's Atlas.hierarchy
+            tree view.
+        """
+
+        # Create QTree widget
+        treeView = QTreeView()
+        treeView.setExpandsOnDoubleClick(False)
+        treeView.setHeaderHidden(True)
+        treeView.setStyleSheet("background-color: rgb(80, 80, 80);") 
+ 
+        treeModel = QStandardItemModel()
+        rootNode = treeModel.invisibleRootItem()
+
+        # Add element's hierarchy
+        tree = self.atlas.hierarchy
+        items = {}
+        for n, node in enumerate(tree.expand_tree()):
+            # Get Node info
+            node = tree.get_node(node)
+            if node.tag in ['VS', 'fiber tracts']: continue 
+
+            # Get brainregion name
+            name = self.atlas._get_from_structure(node.tag, 'name')
+
+            # Create Item
+            item = StandardItem(name, node.tag, tree.depth(node.identifier))
+
+            # Get/assign parents
+            parent = tree.parent(node.identifier)
+            if parent is not None:
+                if parent.identifier not in items.keys():
+                    continue
+                else:
+                    items[parent.identifier].appendRow(item)
+            
+            # Keep track of added nodes
+            items[node.identifier] = item
+            if n == 0:
+                root = item
+
+        # Finish up
+        rootNode.appendRow(root)
+        treeView.setModel(treeModel)
+        treeView.expandToDepth(2)
+
+        # Add callback
+        treeView.doubleClicked.connect(self.show_hide_mesh)
+        return treeView
+
+    def keyPressEvent(self, event):
+      if event.key() == QtCore.Qt.Key_Escape or event.key() == QtCore.Qt.Key_Q:
+         self.close()
+
+

--- a/bgviewer/viewer3d/ui.py
+++ b/bgviewer/viewer3d/ui.py
@@ -5,6 +5,7 @@ from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QMainWindow,
+    QLabel,
 )
 from PyQt5.Qt import QStandardItemModel, QStandardItem, Qt
 from PyQt5.QtGui import QFont, QColor
@@ -76,9 +77,29 @@ class StandardItem(QStandardItem):
 #                                   UI CLASS                                   #
 # ---------------------------------------------------------------------------- #
 
+# for ref: https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qtreeview
+tree_css = """
+QTreeView {background-color: BGCOLOR; border-radius: 12px; padding: 20px 12px;} 
+
+QTreeView::item:hover {
+    background-color: TXTCOLOR; color: BGCOLOR;
+}
+QTreeView::item:selected {
+    background-color: TXTCOLOR; color: BGCOLOR;
+}
+QTreeView::item:selected:active {
+    background-color: TXTCOLOR; color: BGCOLOR;
+}
+
+
+QTreeView::item:selected:!active {
+    background-color: TXTCOLOR; color: BGCOLOR;
+}
+"""
+
 
 class Window(QMainWindow):
-    def __init__(self, *args, theme="dark", **kwargs):
+    def __init__(self, *args, theme="dark", fullscreen=True, **kwargs):
         """
             Create the pyqt window and the widgets
         """
@@ -91,10 +112,13 @@ class Window(QMainWindow):
         self.palette = palettes[theme]
 
         # set the title of main window
-        self.setWindowTitle("Brainrender GUI")
+        self.setWindowTitle("BGVIEWER")
 
         # set the size of window
-        self.showFullScreen()
+        if fullscreen:
+            self.showFullScreen()
+        else:
+            self.resize(1200, 700)
 
         # Change baground color
         self.setStyleSheet(
@@ -113,6 +137,11 @@ class Window(QMainWindow):
         self.left_layout = QVBoxLayout()
 
         self.hierarchy = self.hierarchy_widget()
+        label = QLabel(self.atlas.atlas_name)
+        label.setStyleSheet(
+            f'color: {self.palette["text"]}; font-weight:800; font-size:20px'
+        )
+        self.left_layout.addWidget(label)
         self.left_layout.addWidget(self.hierarchy)
         left_widget = QWidget()
         left_widget.setLayout(self.left_layout)
@@ -156,16 +185,16 @@ class Window(QMainWindow):
             it with structures names from the brainglobe-api's Atlas.hierarchy
             tree view.
         """
+        # Update css
+        css = tree_css.replace("BGCOLOR", self.palette["background"])
+        css = css.replace("TXTCOLOR", self.palette["text"])
+        css = css.replace("HIGHLIGHT", self.palette["highlight"])
 
         # Create QTree widget
         treeView = QTreeView()
         treeView.setExpandsOnDoubleClick(False)
         treeView.setHeaderHidden(True)
-        treeView.setStyleSheet(
-            "background-color: {}; border-radius: 12px; padding: 20px 12px;".format(
-                self.palette["background"]
-            )
-        )
+        treeView.setStyleSheet(css)
 
         treeModel = QStandardItemModel()
         rootNode = treeModel.invisibleRootItem()

--- a/bgviewer/viewer3d/ui.py
+++ b/bgviewer/viewer3d/ui.py
@@ -1,9 +1,15 @@
-from PyQt5.QtWidgets import *
+from PyQt5.QtWidgets import (
+    QTreeView,
+    QHBoxLayout,
+    QTabWidget,
+    QWidget,
+    QVBoxLayout,
+    QMainWindow,
+)
 from PyQt5.Qt import QStandardItemModel, QStandardItem
 from PyQt5.QtGui import QFont, QColor
 from PyQt5 import QtCore
 
-import sys
 from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
 
 
@@ -11,9 +17,9 @@ from vtk.qt.QVTKRenderWindowInteractor import QVTKRenderWindowInteractor
     Handles the UI for the 3d viewer based on the pyqt5 application
 """
 
-# -------------------------------- tree items -------------------------------- #
+
 class StandardItem(QStandardItem):
-    def __init__(self, txt='', tag=None, depth=0):
+    def __init__(self, txt="", tag=None, depth=0):
         """
             Items in the tree list with some
             extended functionality to specify/update
@@ -22,12 +28,12 @@ class StandardItem(QStandardItem):
         super().__init__()
         self.depth = depth  # depth in the hierarchy structure
         self.tag = tag
- 
+
         # Set font color/size
         fs, color = self.get_font_from_depth()
-        self.bold = True # but will be inverted
+        self.bold = True  # but will be inverted
         self.toggle_active()
- 
+
         # Set text
         self.setEditable(False)
         self.setForeground(color)
@@ -42,7 +48,7 @@ class StandardItem(QStandardItem):
         self.bold = not self.bold
         fs, color = self.get_font_from_depth()
 
-        fnt = QFont('Roboto', fs)
+        fnt = QFont("Roboto", fs)
         fnt.setBold(self.bold)
         self.setFont(fnt)
 
@@ -53,7 +59,7 @@ class StandardItem(QStandardItem):
         """
         if self.depth < 2:
             return 16, QColor(255, 255, 255)
-        elif self.depth< 5:
+        elif self.depth < 5:
             return 14, QColor(220, 220, 220)
         else:
             return 16, QColor(180, 180, 180)
@@ -63,6 +69,7 @@ class StandardItem(QStandardItem):
 #                                   UI CLASS                                   #
 # ---------------------------------------------------------------------------- #
 
+
 class Window(QMainWindow):
     def __init__(self):
         """
@@ -71,13 +78,13 @@ class Window(QMainWindow):
         super().__init__()
 
         # set the title of main window
-        self.setWindowTitle('Brainrender GUI')
+        self.setWindowTitle("Brainrender GUI")
 
         # set the size of window
         self.showFullScreen()
 
         # Change baground color
-        self.setStyleSheet("background-color: rgb(40, 40, 40);") 
+        self.setStyleSheet("background-color: rgb(40, 40, 40);")
 
         # add tabs
         self.tab1 = self.brainrender_canvas()
@@ -98,10 +105,12 @@ class Window(QMainWindow):
         # Right layout
         self.right_widget = QTabWidget()
         self.right_widget.tabBar().setObjectName("mainTab")
-        self.right_widget.addTab(self.tab1, '')
+        self.right_widget.addTab(self.tab1, "")
         self.right_widget.setCurrentIndex(0)
-        self.right_widget.setStyleSheet('''QTabBar::tab{width: 0; \
-            height: 0; margin: 0; padding: 0; border: none;}''')
+        self.right_widget.setStyleSheet(
+            """QTabBar::tab{width: 0; \
+            height: 0; margin: 0; padding: 0; border: none;}"""
+        )
 
         # Put everything together
         main_layout = QHBoxLayout()
@@ -137,8 +146,8 @@ class Window(QMainWindow):
         treeView = QTreeView()
         treeView.setExpandsOnDoubleClick(False)
         treeView.setHeaderHidden(True)
-        treeView.setStyleSheet("background-color: rgb(80, 80, 80);") 
- 
+        treeView.setStyleSheet("background-color: rgb(80, 80, 80);")
+
         treeModel = QStandardItemModel()
         rootNode = treeModel.invisibleRootItem()
 
@@ -148,10 +157,11 @@ class Window(QMainWindow):
         for n, node in enumerate(tree.expand_tree()):
             # Get Node info
             node = tree.get_node(node)
-            if node.tag in ['VS', 'fiber tracts']: continue 
+            if node.tag in ["VS", "fiber tracts"]:
+                continue
 
             # Get brainregion name
-            name = self.atlas._get_from_structure(node.tag, 'name')
+            name = self.atlas._get_from_structure(node.tag, "name")
 
             # Create Item
             item = StandardItem(name, node.tag, tree.depth(node.identifier))
@@ -163,7 +173,7 @@ class Window(QMainWindow):
                     continue
                 else:
                     items[parent.identifier].appendRow(item)
-            
+
             # Keep track of added nodes
             items[node.identifier] = item
             if n == 0:
@@ -179,7 +189,8 @@ class Window(QMainWindow):
         return treeView
 
     def keyPressEvent(self, event):
-      if event.key() == QtCore.Qt.Key_Escape or event.key() == QtCore.Qt.Key_Q:
-         self.close()
-
-
+        if (
+            event.key() == QtCore.Qt.Key_Escape
+            or event.key() == QtCore.Qt.Key_Q
+        ):
+            self.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 brainatlas-api
 napari[pyqt5]
+pyqt5
+brainrender

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 brainatlas-api
 napari[pyqt5]
-pyqt5
 brainrender

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,11 @@ setup(
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
     ],
-    entry_points={"console_scripts": ["bgviewer = bgviewer.viewer:main"]},
+    entry_points={
+        "console_scripts": [
+            "bgviewer = bgviewer.viewer:main",
+            "bgviewer3d = bgviewer.viewer3d:main",
+        ]
+    },
     zip_safe=False,
 )


### PR DESCRIPTION
First PR for the 3d viewer, still work in progress but I'd need some input. 

The pyqt5 application subclassess `brainrender.scene.Scene` :
<img width="588" alt="image" src="https://user-images.githubusercontent.com/17436313/84683102-987e6c80-af2e-11ea-8d99-1bcba779fa8e.png">

which means that which `brainglobe-api` atlas is used is handled by `Scene`. In brainrender you pass a python `class` to `Scene`'s `atlas` kwarg. `Scene` then uses the atlas to do all stuff. 
This is different from @adamltyson 's `viewer.py` which let's users select a folder with atlas data and loads them. 

Not sure which option is better, but I guess it will be good to make them work similarly. One reason for not using @adamltyson's solution is that `brainglobe_api.core.Atlas` already handles file paths, data loading etc, so `viewer.py` is replicating a bunch of functionality.  The problem with mine is that currently it can only be done programmatically, would have to be modified for command-line interface.

------
The app is launched with:
```

from bgviewer import viewer3d

viewer3d.launch()
```